### PR TITLE
Update usage of conversationId

### DIFF
--- a/src/xyz/didx/ai/handler/ConfirmOnboardingResult.scala
+++ b/src/xyz/didx/ai/handler/ConfirmOnboardingResult.scala
@@ -25,14 +25,11 @@ object ConfirmOnboardingHandler {
     builder.addUserMessage(input)
 
     // Create a new conversation with the specific conversationId
-    conversation(
-      {
-        val result = prompt[ConfirmedOnboardingResult](builder.build())
-        scribe.info(f"We have the following confirmation result: $result")
-        result
-      },
-      conversationId = Some(ConversationId(conversationId))
-    )
+    conversation {
+      val result = prompt[ConfirmedOnboardingResult](builder.build())
+      scribe.info(f"We have the following confirmation result: $result")
+      result
+    }
   }
 
   def getConfirmationMessage(result: OnboardingResult): String =

--- a/src/xyz/didx/ai/handler/Onboarding.scala
+++ b/src/xyz/didx/ai/handler/Onboarding.scala
@@ -7,10 +7,12 @@ import com.xebia.functional.xef.scala.conversation.*
 import com.xebia.functional.xef.store.ConversationId
 import xyz.didx.ai.model.OnboardingResult
 import xyz.didx.ai.model.AgentScript
+import scala.util.Random
 
 object OnboardingHandler {
   // Define a map from conversationId to JvmPromptBuilder
   private val builders: mutable.Map[String, PromptBuilder] = mutable.Map()
+  private val conversationIds: mutable.Map[String, String] = mutable.Map()
 
   def getResponse(
     input: String,
@@ -23,26 +25,30 @@ object OnboardingHandler {
     )
 
     val defaultPromptBuilder   = AgentScript.createYomaOnboardingBuilder(telNo)
+    val randomString: String   = Random.alphanumeric.take(10).mkString
     val builder: PromptBuilder = cleanSlate match
       case true  =>
         // We want to restart the onboarding on a clean slate, so update builders and use default
+        conversationIds.update(conversationId, randomString) // reset conversationId
         builders.update(conversationId, defaultPromptBuilder)
         defaultPromptBuilder
       case false =>
         // Get the builder for this conversationId, or create a new one if it doesn't exist
+        conversationIds.getOrElseUpdate(conversationId, randomString) // update conversationId if not exists
         builders.getOrElseUpdate(conversationId, defaultPromptBuilder)
 
     // Add the user message to the builder
     builder.addUserMessage(input)
 
     // Create a new conversation with the specific conversationId
+    val xefConversationId = Some(ConversationId(conversationIds.getOrElse(conversationId, "default")))
     conversation(
       {
         val result = prompt[OnboardingResult](builder.build())
         scribe.info(f"We have the following onboarding result: $result")
         result
       },
-      conversationId = Some(ConversationId(conversationId))
+      conversationId = xefConversationId
     )
   }
 }


### PR DESCRIPTION
The confirmation state doesn't require the same conversationId as onboarding state. So, removed its usage from confirmation, and randomise/reset conversationId when onboarding is reset